### PR TITLE
Add ephemeral mode for help messages

### DIFF
--- a/cmd/bot.go
+++ b/cmd/bot.go
@@ -66,7 +66,6 @@ func (b *Bot) OnReady(e *events.Ready) {
 		slog.Error("Failed to configure support channel", slog.Any("err", err))
 	}
 	slog.Info("Bot ready!")
-
 }
 
 func (b *Bot) OnJoin(e *events.GuildJoin) {

--- a/cmd/bot.go
+++ b/cmd/bot.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"time"
@@ -14,6 +15,8 @@ import (
 	"github.com/disgoorg/disgo/gateway"
 	"github.com/disgoorg/paginator"
 	"github.com/disgoorg/snowflake/v2"
+
+	"github.com/kapparina/ticketsplease/cmd/commands"
 )
 
 func New(cfg Config, version, commit, tag string) *Bot {
@@ -54,7 +57,11 @@ func (b *Bot) OnReady(e *events.Ready) {
 	slog.Info("Setting presence...")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := b.Client.SetPresence(ctx, gateway.WithListeningActivity("you"), gateway.WithOnlineStatus(discord.OnlineStatusOnline)); err != nil {
+	if err := b.Client.SetPresence(
+		ctx,
+		gateway.WithCustomActivity(fmt.Sprintf("/%s for support", commands.Help.CommandName())),
+		gateway.WithOnlineStatus(discord.OnlineStatusDND),
+	); err != nil {
 		slog.Error("Failed to set presence", slog.Any("err", err))
 	}
 	slog.Info("Setting up support channel...")

--- a/cmd/commands/commands.go
+++ b/cmd/commands/commands.go
@@ -6,5 +6,5 @@ var Commands = []discord.ApplicationCommandCreate{
 	test,
 	version,
 	Ticket,
-	help,
+	Help,
 }

--- a/cmd/commands/help.go
+++ b/cmd/commands/help.go
@@ -4,7 +4,7 @@ import (
 	"github.com/disgoorg/disgo/discord"
 )
 
-var help = discord.SlashCommandCreate{
+var Help = discord.SlashCommandCreate{
 	Name:        "help",
 	Description: "How to use this app",
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -39,7 +39,7 @@ func GetSupportChannel(b *Bot, guildID *snowflake.ID) (snowflake.ID, error) {
 
 func ConfigureSupportChannel(ctx context.Context, b *Bot, guilds ...snowflake.ID) error {
 	configFunc := func(ctx context.Context, guilds []snowflake.ID) error {
-		eg, ctx := errgroup.WithContext(ctx)
+		eg, _ := errgroup.WithContext(ctx)
 		eg.SetLimit(10)
 		for _, g := range guilds {
 			slog.Info("Setting up support channel for guild", slog.Any("guild_id", g))
@@ -214,7 +214,7 @@ func deleteExistingMessages(b *Bot, c *snowflake.ID) error {
 		return err
 	}
 	deleteMessages := func(ctx context.Context, messages []discord.Message) error {
-		eg, ctx := errgroup.WithContext(ctx)
+		eg, _ := errgroup.WithContext(ctx)
 		eg.SetLimit(10)
 		for _, m := range messages {
 			currentMessage := m

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -165,11 +165,7 @@ func setupSupportChannel(b *Bot, c *snowflake.ID, cmdName string) error {
 		return err
 	}
 	helpData := templates.HelpData{CommandName: cmdName, Version: b.GitTag}
-	content, err := templates.PopulateHelpData(helpData)
-	if err != nil {
-		return err
-	}
-	if err = PostHelpMessage(b, c, content); err != nil {
+	if err := PostHelpMessage(b, c, helpData); err != nil {
 		return err
 	}
 	return nil
@@ -177,11 +173,16 @@ func setupSupportChannel(b *Bot, c *snowflake.ID, cmdName string) error {
 
 // PostHelpMessage sends a message with the given content to a specified Discord channel
 // using the provided bot instance.
-func PostHelpMessage(b *Bot, c *snowflake.ID, content string) error {
-	_, err := b.Client.Rest().CreateMessage(
+func PostHelpMessage(b *Bot, c *snowflake.ID, data templates.HelpData) error {
+	content, err := templates.PopulateHelpData(data)
+	if err != nil {
+		return err
+	}
+	_, err = b.Client.Rest().CreateMessage(
 		*c,
 		discord.NewMessageCreateBuilder().
 			SetContent(content).
+			SetEphemeral(data.Ephemeral).
 			Build(),
 	)
 	if err != nil {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/disgoorg/disgo/discord"
+	"github.com/disgoorg/disgo/handler"
 	"github.com/disgoorg/snowflake/v2"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
@@ -165,7 +166,7 @@ func setupSupportChannel(b *Bot, c *snowflake.ID, cmdName string) error {
 		return err
 	}
 	helpData := templates.HelpData{CommandName: cmdName, Version: b.GitTag}
-	if err := PostHelpMessage(b, c, helpData); err != nil {
+	if err := PostHelpMessage(b, c, helpData, nil); err != nil {
 		return err
 	}
 	return nil
@@ -173,18 +174,32 @@ func setupSupportChannel(b *Bot, c *snowflake.ID, cmdName string) error {
 
 // PostHelpMessage sends a message with the given content to a specified Discord channel
 // using the provided bot instance.
-func PostHelpMessage(b *Bot, c *snowflake.ID, data templates.HelpData) error {
-	content, err := templates.PopulateHelpData(data)
+func PostHelpMessage(b *Bot, c *snowflake.ID, data templates.HelpData, e *handler.CommandEvent) error {
+	var content string
+	var err error
+	if e != nil {
+		content, err = templates.PopulateEphemeralHelpData(data)
+	} else {
+		content, err = templates.PopulateHelpData(data)
+	}
 	if err != nil {
 		return err
 	}
-	_, err = b.Client.Rest().CreateMessage(
-		*c,
-		discord.NewMessageCreateBuilder().
-			SetContent(content).
-			SetEphemeral(data.Ephemeral).
-			Build(),
-	)
+	if e != nil {
+		err = e.CreateMessage(
+			discord.NewMessageCreateBuilder().
+				SetContent(content).
+				SetEphemeral(true).
+				Build(),
+		)
+	} else {
+		_, err = b.Client.Rest().CreateMessage(
+			*c,
+			discord.NewMessageCreateBuilder().
+				SetContent(content).
+				Build(),
+		)
+	}
 	if err != nil {
 		return errors.WithMessage(err, "failed to create help message")
 	}

--- a/cmd/handlers/help.go
+++ b/cmd/handlers/help.go
@@ -1,36 +1,19 @@
 package handlers
 
 import (
-	"github.com/disgoorg/disgo/discord"
 	"github.com/disgoorg/disgo/handler"
-	"github.com/disgoorg/snowflake/v2"
-	"github.com/pkg/errors"
 
 	"github.com/kapparina/ticketsplease/cmd"
+	"github.com/kapparina/ticketsplease/cmd/commands"
+	"github.com/kapparina/ticketsplease/cmd/templates"
 )
 
 func HelpHandler(b *cmd.Bot) handler.CommandHandler {
 	return func(e *handler.CommandEvent) error {
-		c, err := cmd.GetSupportChannel(b, e.GuildID())
-		if err != nil || c == 0 {
-			return errors.WithMessage(err, "failed to get support channel")
-		}
-		if err = sendHelpMessage(e, c); err != nil {
+		helpData := templates.HelpData{CommandName: commands.Ticket.CommandName()}
+		if err := cmd.PostHelpMessage(b, nil, helpData, e); err != nil {
 			return err
 		}
 		return nil
 	}
-}
-
-func sendHelpMessage(e *handler.CommandEvent, c snowflake.ID) error {
-	err := e.CreateMessage(
-		discord.NewMessageCreateBuilder().
-			SetContentf("Please review <#%s>", c).
-			SetEphemeral(true).
-			Build(),
-	)
-	if err != nil {
-		return errors.WithMessage(err, "failed to send help message")
-	}
-	return nil
 }

--- a/cmd/handlers/ticket.go
+++ b/cmd/handlers/ticket.go
@@ -18,6 +18,9 @@ import (
 func CreateTicketHandler(b *cmd.Bot) handler.CommandHandler {
 	return func(e *handler.CommandEvent) error {
 		channelID, err := cmd.GetSupportChannel(b, e.GuildID())
+		if err != nil {
+			return err
+		}
 		threadID, err := createTicketThread(b, channelID, e)
 		if err != nil {
 			return err

--- a/cmd/templates/help-ephemeral.gomd
+++ b/cmd/templates/help-ephemeral.gomd
@@ -1,0 +1,8 @@
+# Support/Suggestions
+
+Asking for help and submitting suggestions both follow the same simple workflow:
+
+1. Type `/{{.CommandName}}` in any channel permitted
+2. Fill in the blanks
+3. Submit
+4. Wait for a response

--- a/cmd/templates/help.gomd
+++ b/cmd/templates/help.gomd
@@ -10,6 +10,8 @@ This channel is not for anything but this very message and hosting ticket thread
 
 # Support/Suggestions
 
+## Server-Related
+
 Asking for help and submitting suggestions both follow the same simple workflow:
 
 1. Type `/{{.CommandName}}` in any channel permitted
@@ -17,7 +19,14 @@ Asking for help and submitting suggestions both follow the same simple workflow:
 3. Submit
 4. Wait for a response
 
--# TicketsPlease Version: {{.Version}}
+## Bot-Related
+
+If you have any questions or suggestions regarding the bot,
+feel free to create an issue on the [GitHub repository](https://github.com/Kapparina/TicketsPlease).
+
 -# If this message has seemingly been reposted, it's because either:
+
 -# 1. The bot has been restarted
 -# 2. The version has changed
+
+-# TicketsPlease Version: {{.Version}}

--- a/cmd/templates/help.gomd
+++ b/cmd/templates/help.gomd
@@ -18,5 +18,6 @@ Asking for help and submitting suggestions both follow the same simple workflow:
 4. Wait for a response
 
 -# TicketsPlease Version: {{.Version}}
--# If this message has seemingly been reposted, it's because either the bot has been restarted or the version has
-changed.
+-# If this message has seemingly been reposted, it's because either:
+-# 1. The bot has been restarted
+-# 2. The version has changed

--- a/cmd/templates/template.go
+++ b/cmd/templates/template.go
@@ -29,7 +29,6 @@ type TicketData struct {
 type HelpData struct {
 	CommandName string
 	Version     string
-	Ephemeral   bool
 }
 
 func PopulateTicketData(data TicketData) (string, error) {
@@ -43,12 +42,16 @@ func PopulateTicketData(data TicketData) (string, error) {
 
 func PopulateHelpData(data HelpData) (string, error) {
 	var buf bytes.Buffer
-	var t *template.Template
-	if data.Ephemeral {
-		t = template.Must(template.New("help-ephemeral").Parse(HelpEphemeralTemplate))
-	} else {
-		t = template.Must(template.New("help").Parse(HelpTemplate))
+	t := template.Must(template.New("help").Parse(HelpTemplate))
+	if err := t.Execute(&buf, data); err != nil {
+		return "", errors.WithMessage(err, "failed to execute help template")
 	}
+	return buf.String(), nil
+}
+
+func PopulateEphemeralHelpData(data HelpData) (string, error) {
+	var buf bytes.Buffer
+	t := template.Must(template.New("help-ephemeral").Parse(HelpEphemeralTemplate))
 	if err := t.Execute(&buf, data); err != nil {
 		return "", errors.WithMessage(err, "failed to execute help template")
 	}

--- a/cmd/templates/template.go
+++ b/cmd/templates/template.go
@@ -14,6 +14,9 @@ var TicketTemplate string
 //go:embed help.gomd
 var HelpTemplate string
 
+//go:embed help-ephemeral.gomd
+var HelpEphemeralTemplate string
+
 type TicketData struct {
 	Category      string
 	Username      string
@@ -26,6 +29,7 @@ type TicketData struct {
 type HelpData struct {
 	CommandName string
 	Version     string
+	Ephemeral   bool
 }
 
 func PopulateTicketData(data TicketData) (string, error) {
@@ -39,7 +43,12 @@ func PopulateTicketData(data TicketData) (string, error) {
 
 func PopulateHelpData(data HelpData) (string, error) {
 	var buf bytes.Buffer
-	t := template.Must(template.New("help").Parse(HelpTemplate))
+	var t *template.Template
+	if data.Ephemeral {
+		t = template.Must(template.New("help-ephemeral").Parse(HelpEphemeralTemplate))
+	} else {
+		t = template.Must(template.New("help").Parse(HelpTemplate))
+	}
 	if err := t.Execute(&buf, data); err != nil {
 		return "", errors.WithMessage(err, "failed to execute help template")
 	}


### PR DESCRIPTION
### Description

This pull request includes significant updates to the Help command implementation and introduces ephemeral mode for help messages. Key changes are:

- **Refactor Help command:**
  - Standardized Help command by updating `help` to `Help` in all relevant references.
  - Improved help message template structure for better readability.
  - Updated bot presence to include Help command in the status message.

- **Enhance error handling:**
  - Improved error handling in `GetSupportChannel` and other functions.
  - Updated context usage in error group handlers.

- **Ephemeral mode for help messages:**
  - Added new `help-ephemeral.go.md` template for ephemeral messages.
  - Adjusted logic in `PopulateHelpData` and `PostHelpMessage` to handle ephemeral flag logic and template selection.

- Minor changes for inline clarity:
  - Removed obsolete or redundant code and improved modularity.
  - Deleted the unused `sendHelpMessage` function and other outdated elements for more concise implementation.
  - Minor style improvements in `bot.go`.

---

### Checklist

- [x] Tests have been updated or added, if applicable.
- [x] Documentation and comments have been reviewed or updated.
- [x] Relevant issue references have been linked.