### PR TITLE
Refactor support channel setup and validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,6 @@ locally built image if preferred.
 
 ## 📄 License
 
+Copyright 2025 Kapparina
+
 This project is licensed under the [Apache Licence 2.0](https://www.apache.org/licenses/LICENSE-2.0). See the [LICENCE](./LICENSE) file for details.

--- a/cmd/commands/ticket.go
+++ b/cmd/commands/ticket.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	MinTicketSubjectLength    = 5
+	MinTicketSubjectLength    = 3
 	MinTicketSubjectLengthPtr = &MinTicketSubjectLength
 	MaxTicketSubjectLength    = 100
 	MaxTicketSubjectLengthPtr = &MaxTicketSubjectLength


### PR DESCRIPTION
- Improved `setupSupportChannel` to better manage existing bot messages.
- Enhanced validation and update process for support help messages.
- Reduced `MinTicketSubjectLength` parameter from 5 to 3 for better accessibility.
- Added logging to confirm successful support channel configurations.
- Refactored `deleteExistingMessages` to allow pre-fetched message input.
- Updated README with necessary copyright information.